### PR TITLE
Add requirements.txt file for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# requirements for https://github.com/estrellagus/iptv-tools
+argparse==1.4.0
+requests==2.32.3


### PR DESCRIPTION
### Summary

The README mentions installing dependencies in step 4 using a `requirements.txt` file, but this file was missing from the repository. This PR adds the missing `requirements.txt` file, enabling users to install the necessary dependencies as instructed.

### Context

From the README:

> **Step 4:** Install the required dependencies using the following command:
> ```bash
> pip install -r requirements.txt
> ```
